### PR TITLE
Fix Update/Refresh/Rekey/timer bugs, correct docs, add invariant fuzz test

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ if value, ok := c.Get("one"); ok {
 }
 
 // Get value and delete it from the cache
-if value, ok := GetAndDelete("two"); ok {
+if value, ok := c.GetAndDelete("two"); ok {
     fmt.Printf("Got and deleted value: %v", value)
 }
 
 // Try getting non-existing value
-if _, ok := Get("two"); !ok {
+if _, ok := c.Get("two"); !ok {
     fmt.Print("Value no longer cached")
 }
 

--- a/cache.go
+++ b/cache.go
@@ -303,13 +303,29 @@ func (c *Cache[K, V]) Range(fn func(K, V) bool) {
 func (c *Cache[K, V]) Rekey(oldKey, newKey K) bool {
 	c.m.Lock()
 
-	item, ok := c.cache[oldKey]
+	v, ok := c.cache[oldKey]
 	if !ok {
 		c.m.Unlock()
 		return false
 	}
 
-	c.cache[newKey] = item
+	if oldKey == newKey {
+		c.m.Unlock()
+		return true
+	}
+
+	if existing, ok := c.cache[newKey]; ok {
+		timerResetNeeded := c.head == existing.Ptr
+
+		c.remove(existing.Ptr)
+
+		if c.head != nil && timerResetNeeded {
+			c.setTimer()
+		}
+	}
+
+	v.Ptr.Key = newKey
+	c.cache[newKey] = v
 	delete(c.cache, oldKey)
 
 	c.m.Unlock()

--- a/cache.go
+++ b/cache.go
@@ -206,6 +206,16 @@ func (c *Cache[K, V]) Refresh(key K, ttl time.Duration) bool {
 
 	start := c.remove(v.Ptr) // Remove the item from the queue to put into a new place
 
+	if start == nil { // It was the only item in the queue
+		v.Ptr.Expires = expires
+		c.head = v.Ptr
+		c.tail = v.Ptr
+		c.setTimer()
+		c.m.Unlock()
+
+		return true
+	}
+
 	if expires.After(v.Ptr.Expires) { // Move towards the tail
 		for n := start; ; n = n.Next {
 			if expires.Before(n.Expires) {

--- a/cache.go
+++ b/cache.go
@@ -9,7 +9,7 @@ type Cache[K comparable, V any] struct {
 	cache map[K]valuePtr[K, V] // Cached items
 	head  *item[K]             // The earliest item to evict, head of the queue
 	tail  *item[K]             // The latest item to evict
-	stop  chan struct{}        // The way to stop the timer
+	timer *time.Timer          // Single expiry timer for the head item
 	m     sync.RWMutex
 }
 
@@ -30,7 +30,6 @@ type item[K comparable] struct {
 func New[K comparable, V any]() *Cache[K, V] {
 	return &Cache[K, V]{
 		cache: make(map[K]valuePtr[K, V]),
-		stop:  make(chan struct{}),
 	}
 }
 
@@ -142,8 +141,12 @@ func (c *Cache[K, V]) Delete(key K) (ok bool) {
 
 	ok = c.delete(key)
 
-	if c.head != nil && timerResetNeeded {
-		c.setTimer()
+	if c.head != nil {
+		if timerResetNeeded {
+			c.setTimer()
+		}
+	} else if ok && c.timer != nil {
+		c.timer.Stop()
 	}
 
 	c.m.Unlock()
@@ -261,16 +264,15 @@ func (c *Cache[K, V]) Refresh(key K, ttl time.Duration) bool {
 func (c *Cache[K, V]) Evict(n int) (evicted int) {
 	c.m.Lock()
 
-	select {
-	case c.stop <- struct{}{}:
-	default:
-	}
-
 	for evicted = 0; evicted < n && c.head != nil && c.delete(c.head.Key); evicted++ {
 	}
 
-	if evicted > 0 && c.head != nil {
-		c.setTimer()
+	if evicted > 0 {
+		if c.head != nil {
+			c.setTimer()
+		} else if c.timer != nil {
+			c.timer.Stop()
+		}
 	}
 
 	c.m.Unlock()
@@ -341,36 +343,39 @@ func (c *Cache[K, V]) Len() int {
 	return len(c.cache)
 }
 
+// setTimer (re)schedules the single expiry timer for the current head.
+// It must be called with c.m held and c.head != nil.
 func (c *Cache[K, V]) setTimer() {
-	select {
-	case c.stop <- struct{}{}:
-	default:
-	}
+	d := time.Until(c.head.Expires)
 
-	go c.ticker(time.NewTimer(time.Until(c.head.Expires)))
-}
+	if c.timer == nil {
+		c.timer = time.AfterFunc(d, c.onTimer)
 
-func (c *Cache[K, V]) ticker(t *time.Timer) {
-	select {
-	case <-t.C:
-	case <-c.stop:
-		t.Stop()
 		return
 	}
 
-	c.m.Lock()
+	c.timer.Reset(d)
+}
 
-	if c.head != nil {
+// onTimer evicts every item that has actually expired and reschedules for
+// the next one. It re-derives all work from live state, so a spurious or
+// stale wake-up (e.g. from a Reset/Stop race) only ever evicts truly
+// expired items and is otherwise a no-op.
+func (c *Cache[K, V]) onTimer() {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	now := time.Now()
+
+	for c.head != nil && !c.head.Expires.After(now) {
 		delete(c.cache, c.head.Key)
 
 		c.remove(c.head)
 	}
 
 	if c.head != nil {
-		c.setTimer()
+		c.timer.Reset(time.Until(c.head.Expires))
 	}
-
-	c.m.Unlock()
 }
 
 func (c *Cache[K, V]) delete(key K) bool {

--- a/cache.go
+++ b/cache.go
@@ -180,7 +180,10 @@ func (c *Cache[K, V]) Update(key K, value V) bool {
 		return false
 	}
 
-	v.Value = value
+	c.cache[key] = valuePtr[K, V]{
+		Value: value,
+		Ptr:   v.Ptr,
+	}
 
 	c.m.Unlock()
 

--- a/cache.go
+++ b/cache.go
@@ -26,14 +26,14 @@ type item[K comparable] struct {
 	Expires time.Time
 }
 
-// New creates a news cache instance, using any comparable type for keys, and any type for values.
+// New creates a new cache instance, using any comparable type for keys and any type for values.
 func New[K comparable, V any]() *Cache[K, V] {
 	return &Cache[K, V]{
 		cache: make(map[K]valuePtr[K, V]),
 	}
 }
 
-// Set adds or replaces a value with key and given TTL.
+// Set adds or replaces the value for key with the given TTL.
 func (c *Cache[K, V]) Set(key K, value V, ttl time.Duration) {
 	c.m.Lock()
 
@@ -82,7 +82,7 @@ func (c *Cache[K, V]) Set(key K, value V, ttl time.Duration) {
 	c.m.Unlock()
 }
 
-// Get returns value and true, if key exists, of zero value and false if not found.
+// Get returns the value and true if the key exists, or the zero value and false if not.
 func (c *Cache[K, V]) Get(key K) (V, bool) {
 	c.m.RLock()
 
@@ -93,7 +93,7 @@ func (c *Cache[K, V]) Get(key K) (V, bool) {
 	return value.Value, ok
 }
 
-// GetMany returns key/value pairs as a map. Will not return non-existing keys/expired values.
+// GetMany returns key/value pairs as a map, omitting keys that are not present.
 func (c *Cache[K, V]) GetMany(keys ...K) map[K]V {
 	values := make(map[K]V)
 
@@ -110,7 +110,7 @@ func (c *Cache[K, V]) GetMany(keys ...K) map[K]V {
 	return values
 }
 
-// Swap sets the new value returning the old one. Will return false if key is not found.
+// Swap sets the new value without changing TTL and returns the old one, or false if the key is not found.
 func (c *Cache[K, V]) Swap(key K, value V) (V, bool) {
 	c.m.Lock()
 
@@ -133,7 +133,7 @@ func (c *Cache[K, V]) Swap(key K, value V) (V, bool) {
 	return oldValue, true
 }
 
-// Delete removes value from thr cache.
+// Delete removes the value for the given key, returning true if it was present.
 func (c *Cache[K, V]) Delete(key K) (ok bool) {
 	c.m.Lock()
 
@@ -154,7 +154,7 @@ func (c *Cache[K, V]) Delete(key K) (ok bool) {
 	return
 }
 
-// GetAndDelete returns value and true, and deletes the key if it was found, of zero value and false if the key not found.
+// GetAndDelete returns the value and true and removes the key if found, or the zero value and false if not.
 func (c *Cache[K, V]) GetAndDelete(key K) (V, bool) {
 	c.m.Lock()
 
@@ -172,7 +172,7 @@ func (c *Cache[K, V]) GetAndDelete(key K) (V, bool) {
 	return value.Value, true
 }
 
-// Update sets new value for key without changing TTL, returning false if key not found.
+// Update sets a new value for the key without changing TTL, returning false if the key is not found.
 func (c *Cache[K, V]) Update(key K, value V) bool {
 	c.m.Lock()
 
@@ -193,7 +193,7 @@ func (c *Cache[K, V]) Update(key K, value V) bool {
 	return true
 }
 
-// Refresh sets new TTL for the given key, returning true if the key (still) exists.
+// Refresh sets a new TTL for the given key, returning true if the key exists.
 func (c *Cache[K, V]) Refresh(key K, ttl time.Duration) bool {
 	c.m.Lock()
 
@@ -280,8 +280,9 @@ func (c *Cache[K, V]) Evict(n int) (evicted int) {
 	return
 }
 
-// Range iterates over key/value pairs using supplied function until it returns false.
-// Values are provided in the order of eviction. It is safe to manipulate the cache within the function.
+// Range calls fn for each key/value pair in eviction order until fn returns false.
+// The keys are captured up front, so it is safe to manipulate the cache from within
+// fn; a key removed before fn observes it yields the zero value.
 func (c *Cache[K, V]) Range(fn func(K, V) bool) {
 	c.m.RLock()
 	keys := make([]K, 0, len(c.cache))
@@ -335,7 +336,7 @@ func (c *Cache[K, V]) Rekey(oldKey, newKey K) bool {
 	return true
 }
 
-// Len returns number of items currently stored in the cache.
+// Len returns the number of items currently stored in the cache.
 func (c *Cache[K, V]) Len() int {
 	c.m.RLock()
 	defer c.m.RUnlock()

--- a/cache_test.go
+++ b/cache_test.go
@@ -192,6 +192,35 @@ func TestRefresh(t *testing.T) {
 	}, 3500*time.Millisecond, 20*time.Millisecond)
 }
 
+func TestRefreshSingleItem(t *testing.T) {
+	t.Run("longer TTL", func(t *testing.T) {
+		c := mcache.New[int, int]()
+		c.Set(1, 1, 30*time.Millisecond)
+
+		assert.True(t, c.Refresh(1, 200*time.Millisecond))
+
+		if v, ok := c.Get(1); assert.True(t, ok) {
+			assert.Equal(t, 1, v)
+		}
+		assert.Equal(t, 1, c.Len())
+
+		assert.Eventually(t, func() bool {
+			return 0 == c.Len()
+		}, 300*time.Millisecond, 10*time.Millisecond)
+	})
+
+	t.Run("shorter TTL", func(t *testing.T) {
+		c := mcache.New[int, int]()
+		c.Set(1, 1, 200*time.Millisecond)
+
+		assert.True(t, c.Refresh(1, 30*time.Millisecond))
+
+		assert.Eventually(t, func() bool {
+			return 0 == c.Len()
+		}, 120*time.Millisecond, 10*time.Millisecond)
+	})
+}
+
 func TestUpdate(t *testing.T) {
 	c := mcache.New[string, string]()
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -197,8 +197,15 @@ func TestUpdate(t *testing.T) {
 
 	c.Set("a", "foo", 20*time.Millisecond)
 	assert.True(t, c.Update("a", "bar"))
+
+	if v, ok := c.Get("a"); assert.True(t, ok) {
+		assert.Equal(t, "bar", v)
+	}
+
 	assert.False(t, c.Update("x", "bar"))
 
+	_, ok := c.Get("x")
+	assert.False(t, ok)
 }
 
 func TestLargeCache(t *testing.T) {

--- a/cache_test.go
+++ b/cache_test.go
@@ -383,6 +383,35 @@ func TestRekeyOntoExisting(t *testing.T) {
 	}, 150*time.Millisecond, 10*time.Millisecond)
 }
 
+func TestTimerNoLeakOnReschedule(t *testing.T) {
+	c := mcache.New[int, int]()
+
+	c.Set(1, 1, time.Hour)
+	require.True(t, c.Refresh(1, time.Hour)) // reschedules the only item
+	require.True(t, c.Delete(1))             // cache now empty
+
+	require.Zero(t, c.Len())
+	// goleak (TestMain) must not find a lingering hour-long timer goroutine.
+}
+
+func TestNoPrematureEviction(t *testing.T) {
+	c := mcache.New[int, int]()
+
+	c.Set(-1, -1, time.Hour) // sentinel: long TTL, must never be evicted early
+
+	for i := 0; i < 500; i++ {
+		c.Set(i, i, 5*time.Millisecond)
+		c.Delete(i)
+	}
+
+	time.Sleep(100 * time.Millisecond) // long past the 5ms churn
+
+	if v, ok := c.Get(-1); assert.True(t, ok, "sentinel evicted before its TTL") {
+		assert.Equal(t, -1, v)
+	}
+	assert.Equal(t, 1, c.Len())
+}
+
 func TestGetMany(t *testing.T) {
 	c := mcache.New[int, string]()
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -345,6 +345,44 @@ func TestRekey(t *testing.T) {
 	require.False(t, c.Rekey("non-existing", "new key"))
 }
 
+func TestRekeyExpires(t *testing.T) {
+	c := mcache.New[string, bool]()
+
+	c.Set("foo", true, 30*time.Millisecond)
+	require.True(t, c.Rekey("foo", "bar"))
+
+	if v, ok := c.Get("bar"); assert.True(t, ok) {
+		assert.True(t, v)
+	}
+
+	// The rekeyed entry must still expire on its original TTL.
+	assert.Eventually(t, func() bool {
+		return 0 == c.Len()
+	}, 200*time.Millisecond, 10*time.Millisecond)
+}
+
+func TestRekeyOntoExisting(t *testing.T) {
+	c := mcache.New[int, int]()
+
+	c.Set(1, 100, 30*time.Millisecond)
+	c.Set(2, 200, 500*time.Millisecond)
+
+	require.True(t, c.Rekey(1, 2)) // key 2 already exists and is displaced
+
+	require.Equal(t, 1, c.Len())
+	if v, ok := c.Get(2); assert.True(t, ok) {
+		assert.Equal(t, 100, v) // value/TTL come from old key 1
+	}
+
+	_, ok := c.Get(1)
+	assert.False(t, ok)
+
+	// Surviving entry keeps key 1's short TTL; no orphaned queue node.
+	assert.Eventually(t, func() bool {
+		return 0 == c.Len()
+	}, 150*time.Millisecond, 10*time.Millisecond)
+}
+
 func TestGetMany(t *testing.T) {
 	c := mcache.New[int, string]()
 

--- a/invariant_test.go
+++ b/invariant_test.go
@@ -1,0 +1,114 @@
+package mcache
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+)
+
+// checkInvariants verifies the internal ordered queue is consistent with the
+// map: same size, doubly-linked both ways, sorted ascending by Expires, and
+// every map entry's Ptr is the queue node carrying the matching key.
+func checkInvariants(t *testing.T, c *Cache[int, int]) {
+	t.Helper()
+
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	if (c.head == nil) != (c.tail == nil) {
+		t.Fatalf("head/tail nil mismatch: head=%v tail=%v", c.head, c.tail)
+	}
+	if c.head != nil && c.head.Prev != nil {
+		t.Fatalf("head.Prev must be nil")
+	}
+	if c.tail != nil && c.tail.Next != nil {
+		t.Fatalf("tail.Next must be nil")
+	}
+
+	seen := map[*item[int]]bool{}
+	var prev *item[int]
+	n := 0
+	for it := c.head; it != nil; it = it.Next {
+		if seen[it] {
+			t.Fatalf("cycle / duplicate node for key %v", it.Key)
+		}
+		seen[it] = true
+
+		if it.Prev != prev {
+			t.Fatalf("broken Prev link at key %v", it.Key)
+		}
+		if prev != nil && it.Expires.Before(prev.Expires) {
+			t.Fatalf("queue not sorted: %v(%v) after %v(%v)",
+				it.Key, it.Expires, prev.Key, prev.Expires)
+		}
+
+		vp, ok := c.cache[it.Key]
+		if !ok {
+			t.Fatalf("queue node key %v missing from map", it.Key)
+		}
+		if vp.Ptr != it {
+			t.Fatalf("map[%v].Ptr does not point to its queue node", it.Key)
+		}
+
+		prev = it
+		n++
+	}
+
+	if n != len(c.cache) {
+		t.Fatalf("queue length %d != map length %d", n, len(c.cache))
+	}
+	if c.tail != prev {
+		t.Fatalf("tail is not the last walked node")
+	}
+}
+
+func TestQueueInvariantsFuzz(t *testing.T) {
+	for _, seed := range []int64{1, 2, 3, 42, 1337} {
+		r := rand.New(rand.NewSource(seed))
+		c := New[int, int]()
+
+		// Long TTLs so the background timer never fires mid-fuzz; this
+		// isolates the Set/Refresh/Rekey/Delete queue logic.
+		ttl := func() time.Duration {
+			return time.Duration(1+r.Intn(1000)) * time.Second
+		}
+		key := func() int { return r.Intn(40) }
+
+		for i := 0; i < 20000; i++ {
+			switch r.Intn(7) {
+			case 0, 1:
+				c.Set(key(), i, ttl())
+			case 2:
+				c.Refresh(key(), ttl())
+			case 3:
+				c.Delete(key())
+			case 4:
+				c.Rekey(key(), key())
+			case 5:
+				c.Swap(key(), i)
+			case 6:
+				c.GetAndDelete(key())
+			}
+			checkInvariants(t, c)
+		}
+
+		// Drain everything via the real expiry timer and verify it empties.
+		c.m.Lock()
+		for it := c.head; it != nil; it = it.Next {
+			it.Expires = time.Now().Add(20 * time.Millisecond)
+		}
+		if c.head != nil {
+			c.setTimer()
+		}
+		c.m.Unlock()
+
+		deadline := time.Now().Add(time.Second)
+		for c.Len() != 0 && time.Now().Before(deadline) {
+			time.Sleep(5 * time.Millisecond)
+		}
+		if l := c.Len(); l != 0 {
+			t.Fatalf("seed %d: cache did not drain, %d left", seed, l)
+		}
+		checkInvariants(t, c)
+	}
+}


### PR DESCRIPTION
## Summary

Found and fixed four real bugs in the cache, each test-first (failing test → fix → green), plus a documentation pass and a white-box fuzz harness. Full `-race` suite green, `goleak` clean, `gofmt`/`vet` clean.

- **`Update()` was a no-op** — it mutated a copy of the map's `valuePtr` struct and never wrote it back, so the cached value never changed. Now writes the new `valuePtr` (preserving the queue node / TTL).
- **`Refresh()` panicked on a single-item cache** — `remove()` empties the list and returns `nil`, then the reinsertion loop dereferenced it. Added an early branch that re-seats the sole item and reschedules.
- **`Rekey()` leaked entries and corrupted the queue** — the queue node's `Key` wasn't updated, so the timer evicted via the stale old key and the renamed entry never expired; rekeying onto an existing key orphaned a queue node. Now updates `Ptr.Key`, handles `oldKey == newKey`, and drops a displaced node (with timer reset).
- **Ticker stop-send race** — the unbuffered `c.stop` + goroutine-per-cycle model could leak ticker goroutines and prematurely evict not-yet-expired items. Replaced with a single struct-held `time.AfterFunc` timer whose callback re-derives work from live state (only evicts genuinely-expired items), so any spurious/stale wake-up is harmless. `Delete`/`Evict` now `Stop()` the timer when the cache empties.
- **Docs** — corrected typos and inaccurate godoc (`New`, `Get`, `GetMany`, `Swap`, `Delete`, `GetAndDelete`, `Update`, `Refresh`, `Range`, `Len`) and fixed two non-compiling README example lines (missing `c.` receiver).
- **Invariant fuzz test** — white-box test running 100k randomized `Set`/`Refresh`/`Rekey`/`Delete`/`Swap`/`GetAndDelete` ops across multiple seeds, asserting the ordered queue stays sorted, doubly-linked both ways, and consistent with the map after every op, plus a timer-drain phase.

## Test plan

- [x] `go test -race -count=1 ./...` — green, `goleak` clean
- [x] `gofmt -l .` — clean
- [x] `go vet ./...` — clean
- [x] Each bug fix has a regression test that was confirmed failing before the fix
- [x] Benchmarks run clean under `-race`
